### PR TITLE
Colorstop type definition changed

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -58,7 +58,7 @@ type GradientColorStop = string | { pos: number; color: string };
 export interface GradientOptions {
   bgColor: string;
   dir?: "h";
-  colorStops: [GradientColorStop, GradientColorStop, ...GradientColorStop[]];
+  colorStops: GradientColorStop[];
 }
 
 export interface LedParameters {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -55,10 +55,15 @@ type EnergyPreset = "peak" | "bass" | "lowMid" | "mid" | "highMid" | "treble";
 
 type GradientColorStop = string | { pos: number; color: string };
 
+type ArrayTwoOrMore<T> = {
+  0: T
+  1: T
+} & Array<T>;
+
 export interface GradientOptions {
   bgColor: string;
   dir?: "h";
-  colorStops: GradientColorStop[];
+  colorStops: ArrayTwoOrMore<GradientColorStop>
 }
 
 export interface LedParameters {


### PR DESCRIPTION
The type definition for colorstops seemed a little strange to me. I have to admit, it worked very well and I don't fully understand how it worked, but I think it can be simplified.

A GradientColorStop object can be a string, or an object.
the colorStops property in GradientOptions is always an array, filled with GradientColorStops.

So, colorStops can be filled with an array full of strings
or
colorStops can be filled with an array full of objects (objects have pos and color attribute)


Because I'm not entirely sure if this is correct, I'd like to ask @alex-greff, is this indeed correct?