### PR TITLE
Fix boolean type for linearBoost to number

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -17,7 +17,7 @@ export interface Options {
   height?: number;
   ledBars?: boolean;
   linearAmplitude?: boolean;
-  linearBoost?: boolean;
+  linearBoost?: number;
   lineWidth?: number;
   loRes?: boolean;
   lumiBars?: boolean;


### PR DESCRIPTION
Hi!

I am trying out the new beta today, and I think there is a small error in the typescript file.
The linearBoost property has been declared as an optional boolean, but I think it's supposed to be a number.
In the [docs](https://github.com/hvianna/audioMotion-analyzer/blob/4.0.0-beta.1/README.md#linearboost-number) it says linearBoost is a number.