### PR TITLE
Correct ESM exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,12 @@
   "main": "./src/audioMotion-analyzer.js",
   "module": "./src/audioMotion-analyzer.js",
   "types": "./src/index.d.ts",
+  "type": "module",
   "exports": {
-    ".": "./src/audioMotion-analyzer.js"
+    ".": {
+      "import": "./src/audioMotion-analyzer.js",
+      "types": "./src/index.d.ts"
+    }
   },
   "files": [
     "src/**/*.js",


### PR DESCRIPTION
This corrects some incorrect parts of the `package.json` ESM config:

1) The package should be listed as `"type": "module"` since [it is written as ESM](https://github.com/hvianna/audioMotion-analyzer/blob/master/src/audioMotion-analyzer.js#L119)

2) The `exports` declaration needs to include the declaration path too.

Without these two fixes this lib is not usable with `'moduleResolution': 'nodenext'` in typescript, and presumably would have issues with later Node versions too, which have the same resolution strategy.