### PR TITLE
Add 3dB/oct and 4.5dB/oct tilt weighting filters

### DIFF
--- a/src/audioMotion-analyzer.js
+++ b/src/audioMotion-analyzer.js
@@ -57,6 +57,8 @@ export const ALPHABARS_FULL            = 'full',
 			 FILTER_C                  = 'C',
 			 FILTER_D                  = 'D',
 			 FILTER_468                = '468',
+			 FILTER_TILT3              = 'TILT3',
+			 FILTER_TILT45             = 'TILT45',
 			 LAYOUT_COMBINED           = 'dual-combined',
 			 LAYOUT_HORIZONTAL         = 'dual-horizontal',
 			 LAYOUT_SINGLE             = 'single',
@@ -809,7 +811,7 @@ class AudioMotionAnalyzer {
 		return this._weightingFilter;
 	}
 	set weightingFilter( value ) {
-		this._weightingFilter = validateFromList( value, [ FILTER_NONE, FILTER_A, FILTER_B, FILTER_C, FILTER_D, FILTER_468 ], 'toUpperCase' );
+		this._weightingFilter = validateFromList( value, [ FILTER_NONE, FILTER_A, FILTER_B, FILTER_C, FILTER_D, FILTER_468, FILTER_TILT3, FILTER_TILT45], 'toUpperCase' );
 	}
 
 	get width() {
@@ -2256,6 +2258,12 @@ class AudioMotionAnalyzer {
 						  h2 = 1.306612257412824e-19 * freq ** 5 - 2.118150887518656e-11 * freq ** 3 + 5.559488023498642e-4 * freq,
 						  rI = 1.246332637532143e-4 * freq / Math.hypot( h1, h2 );
 					return 18.2 + linearTodB( rI );
+
+				case FILTER_TILT3: // 3dB/octave tilt, centered on 1kHz
+					return 3 * Math.log2( freq / 1000 );
+
+				case FILTER_TILT45: // 4.5dB/octave tilt, centered on 1kHz
+					return 4.5 * Math.log2( freq / 1000 );
 			}
 
 			return 0; // unknown filter

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -129,7 +129,7 @@ export type Peaks = "off" | "drop" | "fade";
 
 export type VisualizationMode = "bars" | "graph";
 
-export type WeightingFilter = "" | "A" | "B" | "C" | "D" | "468";
+export type WeightingFilter = "" | "A" | "B" | "C" | "D" | "468" | "TILT3" | "TILT45";
 
 export interface GradientOptions {
   colorStops: GradientColorStop[];


### PR DESCRIPTION
Hello! Thank you for creating such a nice library, I use it daily integrated into Feishin. 

There are 2 weighting filters I would really like to see added to this library, a 3dB/oct tilt and a 4.5dB/oct tilt, with 0dB centered at 1kHz. These are very common weightings used in graphic equalizers for music production (for example, Voxengo SPAN uses the 4.5dB/oct tilt by default). I produce music, so I'm very used to seeing the spectrum tilted. Additionally, a lot of music (modern EDM at least) is balanced against this slope, so this weighting produces a nice flat visualizer.

<img width="606" height="194" alt="image" src="https://github.com/user-attachments/assets/f50ebb4d-74b7-4d8b-951f-f21fe26421ac" />

Above is a 4.5dB/oct filter applied to audiomotion-analyzer, embedded in Feishin. 
